### PR TITLE
Refactor logging: Use fmt.Printf in internal packages, keep zerolog i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.1] 2025-11-03
+
+### Changed
+
+- **Logging Separation**: Refactored logging approach for better separation of concerns
+  - `internal/` packages now use `fmt.Printf` and `panic` instead of zerolog
+  - `cmd/teal` uses standard `fmt` output for CLI logging
+  - `pkg/` packages continue to use zerolog for library-level structured logging
+  - UI assets server (`internal/domain/services/ui_assets_server.go`) now uses simple fmt-based logging
+  - Fatal errors in internal packages now use `panic()` instead of `log.Fatal()`
+  - Error output uses `fmt.Fprintf(os.Stderr, ...)` for consistency
+
 ## [1.0.0] 2025-11-01
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ make:
 
 	rm -rf scaffold/cmd
 	rm -rf scaffold/internal
+	rm -rf scaffold/bin
 
 	if [ -f scaffold/docs/graph.mmd ]; then rm scaffold/docs/graph.mmd; fi;
 	if [ -f scaffold/Makefile ]; then rm scaffold/Makefile; fi;

--- a/pkg/configs/config_service.go
+++ b/pkg/configs/config_service.go
@@ -7,7 +7,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const TEAL_VERSION = "v1.0.0"
+const TEAL_VERSION = "v1.0.1"
 
 type ConfigService struct {
 }


### PR DESCRIPTION
- Replace zerolog with fmt.Printf/panic in internal/domain/services/ui_assets_server.go
- Use simple fmt-based logging for UI assets server startup and errors
- Fatal errors now use panic() instead of log.Fatal() in internal packages
- Remove verbose debug logging from UI asset serving
- pkg/ packages continue using zerolog for structured logging
- Bump version to v1.0.1
- Update CHANGELOG.md with logging separation details
- Clean up scaffold/bin in Makefile

This creates a clear separation: internal/cmd use fmt, pkg uses zerolog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)