### PR TITLE
fix(ui): pass -tags teal_ui when spawning the project UI process

### DIFF
--- a/docs/issues/004-ui-spawn-missing-build-tag.md
+++ b/docs/issues/004-ui-spawn-missing-build-tag.md
@@ -1,0 +1,69 @@
+# Issue #004 — `teal ui` спавнит API-процесс без `-tags teal_ui` (API-половина никогда не собирается)
+
+**Severity:** High — команда `teal ui` из коробки поднимает только статический дашборд;
+API-процесс проекта падает на компиляции, весь функционал UI (DAG, данные ассетов,
+тесты, логи) мёртв.
+
+**Discovered:** 2026-07-17 при отладке `partner-analytics` (AN-01, minikube-БД).
+
+**Status:** ✅ пофикшено локально (ветка `fix/ui-spawn-build-tag`, коммит `050e137`);
+апстрим — TODO (см. Next steps).
+
+---
+
+## Symptom
+
+`teal ui --port 8080` печатает:
+
+```
+Starting UI Dashboard on port 8081 (static assets server)
+✨ UI available at: http://localhost:8081
+Starting UI process: cmd/<project>-ui/<project>-ui.go (port=8080, log_level=debug)
+UI process started (PID=...)
+
+package command-line-arguments
+	imports github.com/go-teal/teal/pkg/ui: build constraints exclude all Go files in .../teal@v1.1.1/pkg/ui
+```
+
+Дашборд (порт `--port + 1`) отдаёт HTML, но все запросы к API (`--port`) падают —
+API-процесс не скомпилировался. Так себя ведут и v1.1.1, и **v1.2.0** (проверено по
+`asset_observer.go` из module cache).
+
+## Root cause
+
+`pkg/ui` и генерируемый scaffold'ом `cmd/<project>-ui/<project>-ui.go` спрятаны за
+build-тегом `teal_ui` (чтобы gin не попадал в прод-бинарь). Но CLI в
+`internal/domain/services/asset_observer.go` запускает процесс так:
+
+```go
+cmd := exec.Command("go", "run", uiPath,
+    "--port", fmt.Sprintf("%d", ao.port),
+    "--log-level", ao.logLevel)
+```
+
+— без `-tags teal_ui`. CLI не может собрать код, который сам же сгенерировал.
+
+## Fix
+
+Одна строка (коммит `050e137` в этом клоне):
+
+```go
+cmd := exec.Command("go", "run", "-tags", "teal_ui", uiPath, ...)
+```
+
+Локальный CLI пересобран: `go install ./cmd/teal` (перекрывает апстримный в
+`$GOBIN`). Проверено end-to-end на `partner-analytics`: `make ui` поднимает и
+дашборд (8081), и API (8080), ошибок сборки нет.
+
+## Next steps
+
+- [ ] PR в апстрим `go-teal/teal` (одна строка + при желании тест на команду спавна).
+- [ ] После релиза апстрима — вернуть CLI на released-версию, локальный патч снять.
+- [ ] Примечание в `partner-analytics/Makefile` (`make ui`) обновить, когда патч
+      перестанет быть нужен.
+
+## Workaround (без патча CLI)
+
+Запускать половинки руками: API — `go run -tags teal_ui ./cmd/<project>-ui --port 8080`
+(в `partner-analytics` это `make run`), дашборд — `teal ui --port 8080` рядом (его
+собственный спавн API падает безвредно, порт держит ручной процесс).

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -10,6 +10,7 @@
 | 001 | Critical | [`pgx.Conn` panic при параллельном выполнении ассетов](./001-pgx-conn-panic-on-parallel-asset-execution.md) | 2026-05-19 | partner-analytics |
 | 002 | High | [scaffold генерирует невалидный `require ... dev` в go.mod](./002-scaffold-go-mod-invalid-version.md) | 2026-05-19 | partner-analytics |
 | 003 | High | [scaffold генерирует unused `pgx/v5` import](./003-scaffold-main-go-unused-pgx-import.md) | 2026-05-19 | partner-analytics |
+| 004 | High | [`teal ui` спавнит API-процесс без `-tags teal_ui`](./004-ui-spawn-missing-build-tag.md) | 2026-07-17 | partner-analytics |
 
 ## Resolved
 

--- a/internal/domain/services/asset_observer.go
+++ b/internal/domain/services/asset_observer.go
@@ -226,7 +226,11 @@ func (ao *AssetObserver) startUIProcess() error {
 
 	fmt.Printf("Starting UI process: %s (port=%d, log_level=%s)\n", uiPath, ao.port, ao.logLevel)
 
-	cmd := exec.Command("go", "run", uiPath,
+	// Local patch (Elstate): the generated cmd/<project>-ui and pkg/ui are
+	// gated behind the `teal_ui` build tag, but upstream spawns `go run`
+	// without it — the UI process always fails to compile (still broken in
+	// v1.2.0). Pass the tag explicitly.
+	cmd := exec.Command("go", "run", "-tags", "teal_ui", uiPath,
 		"--port", fmt.Sprintf("%d", ao.port),
 		"--log-level", ao.logLevel)
 	cmd.Dir = ao.projectPath


### PR DESCRIPTION
The generated `cmd/<project>-ui` and `pkg/ui` are gated behind the `teal_ui` build tag, but `teal ui` spawns `go run` without it — the API half of the debug UI never compiles (`build constraints exclude all Go files in pkg/ui`), broken in v1.1.1 through v1.2.0. One-line fix + issue doc (docs/issues/004).

Verified end-to-end on a real project (partner-analytics): `teal ui --port 8080` now serves both the dashboard (8081) and the API (8080).

🤖 Generated with [Claude Code](https://claude.com/claude-code)