### PR TITLE
fix(drivers): postgres int4/int8 columns degraded to null in DataFrames

### DIFF
--- a/docs/issues/005-pg-dataframe-int-slices-become-null.md
+++ b/docs/issues/005-pg-dataframe-int-slices-become-null.md
@@ -1,0 +1,45 @@
+# Issue #005 — int4/int8 колонки Postgres теряются в DataFrame (везде null)
+
+**Severity:** High — любые integer/bigint колонки (`amocrm_lead_id`, счётчики,
+внешние ID) отображаются как `null` в data-preview дашборда `teal ui` и в любых
+cross-DB dataframe-потоках.
+
+**Discovered:** 2026-07-18 при исследовании данных `partner-analytics`
+(raw.stg_leads: `amocrm_lead_id` «пуст» при заполненной колонке в БД).
+
+**Status:** ✅ RESOLVED — фикс в `fix/pg-dataframe-int-slices`, релиз v1.2.2.
+
+---
+
+## Symptom
+
+`POST /api/dag/asset/:name/select` + `GET /api/dag/asset/:name/data` возвращают
+`"amocrm_lead_id": null` для всех строк, хотя `SELECT` в psql показывает значения.
+Данные в БД целы; ломается только конвертация в DataFrame.
+
+## Root cause
+
+`pkg/drivers/postgres_dataframe.go` (ToDataFrame) накапливал колонки как:
+
+- `int4` → `[]int32`
+- `int8` → `[]int64`
+
+а `series.New` нашего gota-форка поддерживает только `[]int` (кейсов `[]int32` /
+`[]int64` нет) — неизвестный тип слайса деградирует в NA-элементы → `null` в JSON.
+`int2` работал случайно (уже собирался в `[]int`).
+
+## Fix
+
+Все integer-типы (`int2`/`int4`/`int8`) накапливаются в `[]int` с конверсией
+из соответствующих `sql.NullInt*`. `int` 64-битный на всех release-таргетах
+(linux/darwin amd64/arm64) — конверсия из int64 без потерь.
+
+Проверено против живой БД: `SELECT amocrm_lead_id ...` → DataFrame показывает
+реальные значения `<int>`.
+
+## Notes
+
+- DuckDB-драйвер использует собственный маппинг — проверить аналогичный паттерн
+  отдельно, если DuckDB вернётся в работу.
+- Правильный фикс «по-хорошему» — поддержка `[]int32`/`[]int64` в gota-форке;
+  текущий фикс закрывает проблему на стороне teal без релиза gota.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -11,6 +11,7 @@
 | 002 | High | [scaffold генерирует невалидный `require ... dev` в go.mod](./002-scaffold-go-mod-invalid-version.md) | 2026-05-19 | partner-analytics |
 | 003 | High | [scaffold генерирует unused `pgx/v5` import](./003-scaffold-main-go-unused-pgx-import.md) | 2026-05-19 | partner-analytics |
 | 004 | High | [`teal ui` спавнит API-процесс без `-tags teal_ui`](./004-ui-spawn-missing-build-tag.md) | 2026-07-17 | partner-analytics |
+| 005 | High | [int4/int8 колонки теряются в DataFrame — везде null](./005-pg-dataframe-int-slices-become-null.md) | 2026-07-18 | partner-analytics |
 
 ## Resolved
 

--- a/pkg/drivers/postgres_dataframe.go
+++ b/pkg/drivers/postgres_dataframe.go
@@ -146,12 +146,11 @@ func (d *PostgresDBEngine) ToDataFrame(sqlQuery string) (*dataframe.DataFrame, e
 			seriesData[i] = make([]string, 0)
 		case "numeric", "float4", "float8":
 			seriesData[i] = make([]float64, 0)
-		case "int2":
+		case "int2", "int4", "int8":
+			// gota's series.New only understands []int (no []int32/[]int64
+			// cases — unknown slice types degrade to NA/null, see issue #005).
+			// int is 64-bit on every release target, so this is lossless.
 			seriesData[i] = make([]int, 0)
-		case "int4":
-			seriesData[i] = make([]int32, 0)
-		case "int8":
-			seriesData[i] = make([]int64, 0)
 		case "bool":
 			seriesData[i] = make([]bool, 0)
 		default:
@@ -212,14 +211,14 @@ func (d *PostgresDBEngine) ToDataFrame(sqlQuery string) (*dataframe.DataFrame, e
 				sd = append(sd, int(val.Int16))
 				seriesData[i] = sd
 			case "int4":
-				sd := seriesData[i].([]int32)
+				sd := seriesData[i].([]int)
 				val := safeData[i].(*sql.NullInt32)
-				sd = append(sd, int32(val.Int32))
+				sd = append(sd, int(val.Int32))
 				seriesData[i] = sd
 			case "int8":
-				sd := seriesData[i].([]int64)
+				sd := seriesData[i].([]int)
 				val := safeData[i].(*sql.NullInt64)
-				sd = append(sd, int64(val.Int64))
+				sd = append(sd, int(val.Int64))
 				seriesData[i] = sd
 			case "bool":
 				sd := seriesData[i].([]bool)


### PR DESCRIPTION
gota's series.New only handles `[]int` — `[]int32`/`[]int64` fall through to NA elements, so every integer/bigint column rendered as null in the teal ui data preview (and any cross-DB dataframe flow). Accumulate all integer pg types as `[]int` (64-bit on all release targets, lossless). Verified against a live database; docs/issues/005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)