### PR TITLE
fix(api): asset select previews the materialized relation for non-SELECT models

### DIFF
--- a/docs/issues/006-asset-select-executes-model-script.md
+++ b/docs/issues/006-asset-select-executes-model-script.md
@@ -1,0 +1,25 @@
+# Issue #006 — «Select» ассета исполняет SQL модели: 42601 на мульти-стейтментных и риск мутаций
+
+**Severity:** High — предпросмотр данных падает на SCD2/custom-моделях
+(`ERROR: cannot insert multiple commands into a prepared statement, SQLSTATE 42601`),
+а будь протокол попроще — кнопка предпросмотра ИСПОЛНЯЛА бы UPDATE/INSERT модели.
+
+**Discovered:** 2026-07-18 при исследовании `partner-analytics` (Select на
+`core.dim_partner` — SCD2-скрипт из 8 стейтментов).
+
+**Status:** ✅ RESOLVED — fix в `fix/asset-select-from-relation`, релиз v1.2.4.
+
+## Root cause
+
+`ExecuteAssetSelect` рендерил `RawSQL` модели и запускал его через
+`ToDataFrame` как есть. Для table/view-моделей это одиночный SELECT и работает;
+для SCD2/custom-моделей — многокомандный скрипт: pgx (extended protocol) его
+запрещает, а семантика «предпросмотр = выполнить мутации» неверна в принципе.
+
+## Fix
+
+Если отрендеренный SQL — не одиночный read-only SELECT/WITH (проверка
+`isSingleReadOnlySelect`: комментарии пропускаются, внутренние `;` запрещены),
+предпросмотр читает **материализованное отношение**: `SELECT * FROM <schema>.<asset>`.
+Точка с запятой в строковом литерале даёт ложное срабатывание — деградация
+безопасная (тоже уходим на relation-preview). Юнит-тесты приложены.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -12,6 +12,7 @@
 | 003 | High | [scaffold генерирует unused `pgx/v5` import](./003-scaffold-main-go-unused-pgx-import.md) | 2026-05-19 | partner-analytics |
 | 004 | High | [`teal ui` спавнит API-процесс без `-tags teal_ui`](./004-ui-spawn-missing-build-tag.md) | 2026-07-17 | partner-analytics |
 | 005 | High | [int4/int8 колонки теряются в DataFrame — везде null](./005-pg-dataframe-int-slices-become-null.md) | 2026-07-18 | partner-analytics |
+| 006 | High | [«Select» ассета исполняет SQL модели — 42601 на SCD2, риск мутаций](./006-asset-select-executes-model-script.md) | 2026-07-18 | partner-analytics |
 
 ## Resolved
 

--- a/pkg/services/debugging/debugging_service.go
+++ b/pkg/services/debugging/debugging_service.go
@@ -1163,15 +1163,30 @@ func (s *DebuggingService) ExecuteAssetSelect(assetName, taskId string) <-chan A
 				return
 			}
 
+			// Guard (issue #006): a rendered model may be a multi-statement
+			// script (SCD2 / custom materializations). Executing it here would
+			// both fail — pgx's extended protocol forbids multiple commands in
+			// one prepared statement (SQLSTATE 42601) — and, worse, RUN the
+			// model's mutations from a data-preview button. For anything that
+			// is not a single read-only SELECT, preview the materialized
+			// relation instead.
+			querySQL := renderedSQL
+			if !isSingleReadOnlySelect(renderedSQL) {
+				querySQL = fmt.Sprintf("SELECT * FROM %s", sqlModelDesc.Name)
+				log.Debug().
+					Str("assetName", assetName).
+					Msg("model SQL is not a single SELECT — previewing the materialized relation instead")
+			}
+
 			log.Debug().
 				Str("taskId", taskId).
 				Str("taskUUID", taskUUID).
 				Str("assetName", assetName).
-				Str("sql", renderedSQL).
+				Str("sql", querySQL).
 				Msg("Executing SQL select query")
 
 			// Execute the SQL query (long operation - no lock)
-			df, err := dbConnection.ToDataFrame(renderedSQL)
+			df, err := dbConnection.ToDataFrame(querySQL)
 
 			endTime := time.Now()
 			endTimeMs := endTime.UnixMilli()
@@ -1583,4 +1598,42 @@ func (s *DebuggingService) GetTestData(testName, taskId string) TestDataResponse
 	}
 
 	return response
+}
+
+// isSingleReadOnlySelect reports whether the rendered model SQL is a single
+// read-only SELECT/WITH statement — the only shape ExecuteAssetSelect may run
+// verbatim. Multi-statement scripts (SCD2, custom materializations) and
+// anything that does not start with SELECT/WITH must be previewed via the
+// materialized relation instead (see issue #006). A semicolon inside a string
+// literal yields a false negative, which safely degrades to the relation
+// preview.
+func isSingleReadOnlySelect(sqlText string) bool {
+	s := strings.TrimSpace(sqlText)
+	s = strings.TrimSuffix(s, ";")
+	if strings.Contains(s, ";") {
+		return false
+	}
+	// Skip leading comments before the first keyword.
+	for {
+		s = strings.TrimSpace(s)
+		if strings.HasPrefix(s, "--") {
+			i := strings.Index(s, "\n")
+			if i < 0 {
+				return false
+			}
+			s = s[i+1:]
+			continue
+		}
+		if strings.HasPrefix(s, "/*") {
+			i := strings.Index(s, "*/")
+			if i < 0 {
+				return false
+			}
+			s = s[i+2:]
+			continue
+		}
+		break
+	}
+	up := strings.ToUpper(s)
+	return strings.HasPrefix(up, "SELECT") || strings.HasPrefix(up, "WITH")
 }

--- a/pkg/services/debugging/select_preview_test.go
+++ b/pkg/services/debugging/select_preview_test.go
@@ -1,0 +1,26 @@
+package debugging
+
+import "testing"
+
+func TestIsSingleReadOnlySelect(t *testing.T) {
+	cases := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{"plain select", "SELECT * FROM raw.stg_leads", true},
+		{"trailing semicolon", "select id from t;", true},
+		{"with cte", "WITH x AS (SELECT 1) SELECT * FROM x", true},
+		{"leading line comment", "-- snapshot\nSELECT 1", true},
+		{"leading block comment", "/* profile */ SELECT 1", true},
+		{"scd2 script", "UPDATE t SET a=1;\nINSERT INTO t VALUES (1);", false},
+		{"multi select", "SELECT 1;\nSELECT 2;", false},
+		{"ddl", "CREATE INDEX i ON t(a)", false},
+		{"semicolon in literal degrades safely", "SELECT ';' AS c FROM t WHERE x = 1; SELECT 2", false},
+	}
+	for _, c := range cases {
+		if got := isSingleReadOnlySelect(c.sql); got != c.want {
+			t.Errorf("%s: isSingleReadOnlySelect(%q) = %v, want %v", c.name, c.sql, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
`ExecuteAssetSelect` ran the rendered model SQL verbatim: multi-statement scripts (SCD2/custom) fail under pgx's extended protocol (SQLSTATE 42601), and running them from a data-preview button would execute the model's mutations. When the rendered SQL is not a single read-only SELECT/WITH, preview `SELECT * FROM <schema>.<asset>` instead. Unit tests included; docs/issues/006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)