### PR TITLE
fix(gen): do not clobber an existing Makefile on teal gen

### DIFF
--- a/docs/issues/007-gen-makefile-clobbers-user-edits.md
+++ b/docs/issues/007-gen-makefile-clobbers-user-edits.md
@@ -1,0 +1,44 @@
+# Issue #007 — `teal gen` затирает пользовательский Makefile при каждой регенерации
+
+**Severity:** High — ручные правки Makefile теряются на любом `teal gen`
+(а `make run` вызывает `teal gen` внутри), молча ломая кастомные таргеты.
+
+**Discovered:** 2026-07-18 в `partner-analytics`: добавленные таргеты
+`ui` / `run` / `check-minikube-db` (env-обвязка под minikube postgresql,
+влиты в develop) исчезли после `teal gen` — `make ui` перестал существовать.
+
+**Status:** ✅ RESOLVED — fix в `fix/gen-makefile-skip-existing`, релиз vX.Y.Z.
+
+## Root cause
+
+`internal/domain/generators/gen_makefile.go::RenderToFile` безусловно
+делал `os.Create` и перезаписывал `Makefile` шаблоном на каждом gen.
+
+Все остальные скаффолд-генераторы, которые проект кастомизирует —
+`go.mod` (`gen_go_mod.go`), `main.go` (`gen_main.go`), `main-ui.go`,
+`Dockerfile` (`gen_dockerfile.go`) — реализуют skip-if-exists: `os.Stat`
+на целевой путь, при существовании возвращают `(nil, true)` → `[SKIPPED]`.
+`Makefile` был единственным исключением, хотя это ровно такой же
+одноразовый скаффолд, который дальше правит разработчик.
+
+## Fix
+
+Добавлен тот же guard в `GenMakefile.RenderToFile`:
+
+```go
+if _, err := os.Stat(g.GetFullPath()); err == nil {
+    return nil, true // существующий Makefile не трогаем
+}
+```
+
+Регенерация происходит только если файла нет (как и просил кейс). Чтобы
+получить свежий шаблон, Makefile нужно удалить перед gen — идентично
+поведению go.mod / main.go / Dockerfile.
+
+Тесты: `internal/domain/generators/gen_makefile_test.go`
+(skip при наличии файла + генерация при отсутствии).
+
+## Impact на partner-analytics
+
+Восстановлен Makefile из git (таргеты `ui`/`run`/`check-minikube-db`).
+После апдейта teal CLI регенерация его больше не тронет.

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -13,6 +13,7 @@
 | 004 | High | [`teal ui` спавнит API-процесс без `-tags teal_ui`](./004-ui-spawn-missing-build-tag.md) | 2026-07-17 | partner-analytics |
 | 005 | High | [int4/int8 колонки теряются в DataFrame — везде null](./005-pg-dataframe-int-slices-become-null.md) | 2026-07-18 | partner-analytics |
 | 006 | High | [«Select» ассета исполняет SQL модели — 42601 на SCD2, риск мутаций](./006-asset-select-executes-model-script.md) | 2026-07-18 | partner-analytics |
+| 007 | High | [`teal gen` затирает пользовательский Makefile](./007-gen-makefile-clobbers-user-edits.md) | 2026-07-18 | partner-analytics |
 
 ## Resolved
 

--- a/internal/domain/generators/gen_makefile.go
+++ b/internal/domain/generators/gen_makefile.go
@@ -32,6 +32,14 @@ func (g *GenMakefile) GetFullPath() string {
 }
 
 func (g *GenMakefile) RenderToFile() (error, bool) {
+	// The Makefile is scaffolding the developer is expected to customize
+	// (extra targets, env wiring). Like go.mod / main.go / Dockerfile, skip
+	// regeneration when it already exists so `teal gen` never clobbers hand
+	// edits. Delete the file to force a fresh template on the next gen.
+	if _, err := os.Stat(g.GetFullPath()); err == nil {
+		return nil, true
+	}
+
 	tmpl, err := pongo2.FromString(makefileTemplate)
 	if err != nil {
 		return err, false

--- a/internal/domain/generators/gen_makefile_test.go
+++ b/internal/domain/generators/gen_makefile_test.go
@@ -1,0 +1,58 @@
+package generators
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-teal/teal/pkg/configs"
+)
+
+// The Makefile is developer-editable scaffolding; teal gen must not clobber
+// an existing one. Mirrors the skip-if-exists behaviour of go.mod / main.go /
+// Dockerfile generators.
+func TestGenMakefileSkipsExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &configs.Config{ProjectPath: dir}
+	profile := &configs.ProjectProfile{}
+	g := InitGenMakefile(cfg, profile)
+
+	// Pre-existing hand-edited Makefile must survive gen untouched.
+	custom := []byte("# custom\nui:\n\techo hi\n")
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), custom, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err, skipped := g.RenderToFile()
+	if err != nil {
+		t.Fatalf("RenderToFile: %v", err)
+	}
+	if !skipped {
+		t.Fatal("expected existing Makefile to be skipped, was overwritten")
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "Makefile"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(custom) {
+		t.Fatalf("existing Makefile was modified:\n%s", got)
+	}
+}
+
+func TestGenMakefileGeneratesWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &configs.Config{ProjectPath: dir}
+	profile := &configs.ProjectProfile{Name: "demo"}
+	g := InitGenMakefile(cfg, profile)
+
+	err, skipped := g.RenderToFile()
+	if err != nil {
+		t.Fatalf("RenderToFile: %v", err)
+	}
+	if skipped {
+		t.Fatal("expected a fresh Makefile to be generated, got skipped")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "Makefile")); err != nil {
+		t.Fatalf("Makefile not written: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`teal gen` overwrote the project `Makefile` on **every** run, wiping any developer-added targets. Since `make run` invokes `teal gen` internally, custom targets silently vanished on the next `make run`.

Hit in a downstream project where custom `ui` / `run` targets (minikube DB env wiring) disappeared after a routine gen — `make ui` ceased to exist.

## Root cause

`internal/domain/generators/gen_makefile.go::RenderToFile` did an unconditional `os.Create`. Every other scaffolding generator the developer is expected to edit — `go.mod`, `main.go`, `main-ui.go`, `Dockerfile` — already guards with `os.Stat` and returns `(nil, true)` → `[SKIPPED]` when the file exists. The Makefile was the lone exception.

## Fix

Same skip-if-exists guard: regenerate the Makefile only when it's absent. Delete it to force a fresh template (identical to the go.mod/main.go/Dockerfile contract).

Adds `gen_makefile_test.go` covering both branches (skip when present, generate when absent). Documented as `docs/issues/007`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)